### PR TITLE
per-language notifications and new original string notifications

### DIFF
--- a/includes/class.GPNotifyFilterUsers.php
+++ b/includes/class.GPNotifyFilterUsers.php
@@ -10,6 +10,8 @@ if (!defined('ABSPATH')) {
 class GPNotifyFilterUsers {
 
 	protected $project_id;
+	protected $locale;
+	protected $frequency;
 
 	/**
 	* filter the array, returning only users subscribed to specified project
@@ -17,8 +19,10 @@ class GPNotifyFilterUsers {
 	* @param int $project_id
 	* @return array
 	*/
-	public function execute($users, $project_id) {
+	public function execute($users, $project_id, $locale = false, $frequency = false) {
 		$this->project_id = $project_id;
+		$this->locale = $locale;
+		$this->frequency = $frequency;
 		return array_filter($users, array($this, '_filter'));
 	}
 
@@ -28,7 +32,13 @@ class GPNotifyFilterUsers {
 	* @return bool
 	*/
 	public function _filter($user) {
-		return !empty($user->projects[$this->project_id]);
+		if( empty($this->frequency) || (!empty($user->projects['frequency']) && in_array($this->frequency, $user->projects['frequency'])) ){
+			if( !empty($this->locale) ){
+				return !empty($user->projects['waiting'][$this->project_id][$this->locale]);
+			}else{
+				return !empty($user->projects['waiting'][$this->project_id]) && !is_array($user->projects['waiting'][$this->project_id]);			
+			}
+		}
 	}
 
 }

--- a/includes/class.GPNotifyWaiting.php
+++ b/includes/class.GPNotifyWaiting.php
@@ -29,7 +29,7 @@ class GPNotifyWaiting {
 	* @param string $subject
 	* @param array $translations
 	*/
-	public function compose($subject, $translations) {
+	public function compose($subject, $translations, $scope) {
 		$title   = apply_filters('gnotify_waiting_title', $subject, $translations, $this->users);
 		$subject = apply_filters('gnotify_waiting_subject', $subject, $translations, $this->users);
 

--- a/templates/email-waiting.php
+++ b/templates/email-waiting.php
@@ -11,30 +11,30 @@ if (!defined('ABSPATH')) {
 <title><?php echo esc_html($subject); ?></title>
 <style>
 body { sans-serif; color: #333; }
-table { border-collapse: collapse; border-spacing: 0; }
-td, th { border: 1px solid #ccc; padding: 2px; }
-th { text-align: left; }
+table { }
+td, th { }
+th {  }
 .num { text-align: right; }
 </style>
 </head>
 
 <body>
-	<p><strong><?php echo esc_html($title); ?></strong></p>
+	<p><?php echo sprintf(esc_html__('Below are new translations awaiting approval over the past %s.', 'glotpress-notify'), $scope); ?></p>
 
-	<table>
+	<table style="width:440px; text-align:center; border-collapse: collapse; border-spacing: 0;">
 		<thead>
-		<tr>
-			<th><?php echo esc_html_x('Language', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th><?php echo esc_html_x('Locale', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th class="num"><?php echo esc_html_x('Current', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th class="num"><?php echo esc_html_x('Waiting', 'translation list heading', 'glotpress-notify'); ?></th>
+		<tr style="text-align: center;">
+			<th style="border: 1px solid #ccc; padding: 2px;"><?php echo esc_html_x('Language', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px;"><?php echo esc_html_x('Locale', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px; text-align: center;" class="num"><?php echo esc_html_x('Current', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px; text-align: center;" class="num"><?php echo esc_html_x('Waiting', 'translation list heading', 'glotpress-notify'); ?></th>
 		</tr>
 		</thead>
 
 		<tbody>
 		<?php foreach ($translations as $translation) { ?>
 		<tr>
-			<td><?php
+			<td style="border: 1px solid #ccc; padding: 2px;"><?php
 				if (empty($translation->translation_uri)) {
 					echo esc_html($translation->locale_name);
 				}
@@ -42,23 +42,28 @@ th { text-align: left; }
 					printf('<a href="%s" target="_blank">%s</a>', esc_url($translation->translation_uri), esc_html($translation->locale_name));
 				}
 			?></td>
-			<td><?php echo esc_html($translation->locale); ?></td>
-			<td class="num"><?php echo esc_html($translation->current); ?></td>
-			<td class="num"><?php echo esc_html($translation->waiting); ?></td>
+			<td style="border: 1px solid #ccc; padding: 2px;"><?php echo esc_html($translation->locale); ?></td>
+			<td class="num" style="text-align:center; border: 1px solid #ccc; padding: 2px;"><?php echo esc_html($translation->current); ?></td>
+			<td class="num" style="text-align:center; border: 1px solid #ccc; padding: 2px;"><?php echo esc_html($translation->waiting); ?></td>
 		</tr>
 		<?php } ?>
 		</tbody>
-
+		<?php if( count($translations) > 10 ) : ?>
 		<tfoot>
 		<tr>
-			<th><?php echo esc_html_x('Language', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th><?php echo esc_html_x('Locale', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th class="num"><?php echo esc_html_x('Current', 'translation list heading', 'glotpress-notify'); ?></th>
-			<th class="num"><?php echo esc_html_x('Waiting', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px;"><?php echo esc_html_x('Language', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px;"><?php echo esc_html_x('Locale', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px; text-align: center;" class="num"><?php echo esc_html_x('Current', 'translation list heading', 'glotpress-notify'); ?></th>
+			<th style="border: 1px solid #ccc; padding: 2px; text-align: center;" class="num"><?php echo esc_html_x('Waiting', 'translation list heading', 'glotpress-notify'); ?></th>
 		</tr>
 		</tfoot>
+		<?php endif; ?>
 
-	</table>
+	</table> 
+	
+	<p><?php echo sprintf(esc_html__('You have received this email because you have subscribed to receive notifcations of new translations on %s.', 'glotpress-notify'), get_bloginfo('url')); ?></p>
+	
+	<p><?php echo sprintf(esc_html__('To change your notification settings, please visit your account here - %s', 'glotpress-notify'), admin_url('admin.php?page=gpnotify-profile')); ?></p>
 </body>
 
 </html>

--- a/views/admin-bad-prefix.php
+++ b/views/admin-bad-prefix.php
@@ -9,8 +9,7 @@ if (!defined('ABSPATH')) {
 <div class="wrap">
 
 	<div class="error">
-		<p><?php esc_html_e('GlotPress Notify has an invalid GlotPress table prefix.', 'gpnotify'); ?></p>
+		<p><?php esc_html_e('GlotPress Notify has an invalid GlotPress table prefix.', 'glotpress-notify'); ?></p>
 	</div>
 
 </div>
-

--- a/views/admin-list-projects.php
+++ b/views/admin-list-projects.php
@@ -8,17 +8,27 @@ if (!defined('ABSPATH')) {
 
 <div class="wrap">
 
-	<h2><?php esc_html_e('GlotPress Notify Projects', 'gpnotify'); ?></h2>
+	<h2><?php esc_html_e('GlotPress Notify Projects', 'glotpress-notify'); ?></h2>
+	
+	<?php 
+	$scope_links = array();
+	$scopes = array('all' => __('View All', 'glotpress-notify'), 'day' => __('Today','glotpress-notify'), 'week' => __('This Week', 'glotpress-notify'), 'month' => __('This Month', 'glotpress-notify'));
+	foreach( $scopes as $s => $v){
+		$class_active = ( $scope == $s ) ? ' style="font-weight:bold"' : '';
+		$scope_links[] = '<a href="'.esc_url(add_query_arg('scope', $s)) ."\"$class_active>".esc_html($v).'</a>';
+	}
+	?>
+	<p><?php echo implode(' | ', $scope_links); ?></p>
 
 	<?php if (count($waiting) === 0): ?>
 
-		<p><?php esc_html_e('There are no GlotPress projects with translations waiting for approval.', 'gpnotify'); ?></p>
+		<p><?php esc_html_e('There are no GlotPress projects with translations waiting for approval.', 'glotpress-notify'); ?></p>
 
 	<?php else: ?>
 
 		<?php foreach ($waiting as $project_id => $translations) { ?>
 
-		<h3><?php echo esc_html($projects[$project_id]->name); ?></h3>
+		<h3><a href="<?php echo esc_url(gp_url_project( $projects[$project_id]->slug )); ?>"><?php echo esc_html($projects[$project_id]->name); ?></a></h3>
 
 		<table class="wp-list-table widefat fixed">
 			<thead>
@@ -35,14 +45,7 @@ if (!defined('ABSPATH')) {
 				$tr_class = ($i % 2) ? '' : 'class="alternate"';
 				?>
 				<tr <?php echo $tr_class; ?>>
-					<td><?php
-						if (empty($translation->translation_uri)) {
-							echo esc_html($translation->locale_name);
-						}
-						else {
-							printf('<a href="%s" target="_blank">%s</a>', esc_url($translation->translation_uri), esc_html($translation->locale_name));
-						}
-					?></td>
+					<td><a href="<?php echo esc_url(gp_url_project_locale( $projects[$project_id]->slug, $translation->locale, $translation->slug )); ?>"><?php echo esc_html($translation->locale_name); ?></td>
 					<td><?php echo esc_html($translation->locale); ?></td>
 					<td class="num"><?php echo esc_html($translation->current); ?></td>
 					<td class="num"><?php echo esc_html($translation->waiting); ?></td>

--- a/views/admin-user-fields.php
+++ b/views/admin-user-fields.php
@@ -8,8 +8,8 @@ if (!defined('ABSPATH')) {
 
 <div class="wrap">
 
-	<h2><?php esc_html_e('GlotPress Notify Subscriptions', 'gpnotify'); ?></h2>
-	<p><?php esc_html_e('Receive notifications for GlotPress translation projects.', 'gpnotify'); ?></p>
+	<h2><?php esc_html_e('GlotPress Notify Subscriptions', 'glotpress-notify'); ?></h2>
+	<p><?php esc_html_e('Receive notifications for GlotPress translation projects.', 'glotpress-notify'); ?></p>
 
 	<?php if ($update_message): ?>
 	<div class="updated">
@@ -25,6 +25,7 @@ if (!defined('ABSPATH')) {
 				<tr>
 					<th><?php echo esc_html_x('Project name', 'subscription settings', 'glotpress-notify'); ?></th>
 					<th><?php echo esc_html_x('Project slug', 'subscription settings', 'glotpress-notify'); ?></th>
+					<th><?php echo esc_html_x('Language', 'subscription settings', 'glotpress-notify'); ?></th>
 					<th><?php echo esc_html_x('Waiting', 'subscription settings', 'glotpress-notify'); ?></th>
 				</tr>
 			</thead>
@@ -33,16 +34,16 @@ if (!defined('ABSPATH')) {
 				<tr>
 					<th><?php echo esc_html_x('Project name', 'subscription settings', 'glotpress-notify'); ?></th>
 					<th><?php echo esc_html_x('Project slug', 'subscription settings', 'glotpress-notify'); ?></th>
+					<th><?php echo esc_html_x('Language', 'subscription settings', 'glotpress-notify'); ?></th>
 					<th><?php echo esc_html_x('Waiting', 'subscription settings', 'glotpress-notify'); ?></th>
 				</tr>
 			</tfoot>
 
-			<tbody>
 			<?php $i = 0; foreach ($projects as $project) {
 				$tr_class = ($i % 2) ? '' : 'class="alternate"';
 
 				$fieldbase = "gpnotify_projects_{$project->id}";
-				$waiting = empty($project_options['waiting'][$project->id]) ? 0 : 1;
+				$waiting = empty($project_options['waiting'][$project->id]) || is_array($project_options['waiting'][$project->id]) ? 0 : 1;
 				?>
 
 				<tr <?php echo $tr_class; ?>>
@@ -55,20 +56,56 @@ if (!defined('ABSPATH')) {
 						}
 					?></td>
 					<td><?php echo esc_html($project->slug); ?></td>
-					<td><input type="checkbox" name="<?php echo $fieldbase; ?>_waiting" <?php checked($waiting); ?> value="1" /></td>
+					<td></td>
+					<td><input type="checkbox" class="project-notify" id="project-<?php echo esc_attr($project->slug); ?>" name="<?php echo $fieldbase; ?>_waiting" <?php checked($waiting); ?> value="1" /></td>
 				</tr>
-
+				<tbody class="project-<?php echo esc_attr($project->slug); ?>-langs">
+				<?php 
+					foreach( $translation_sets[$project->id] as $translation_set ){
+						$set_waiting = $waiting || !empty($project_options['waiting'][$project->id][$translation_set->locale]) ? 1 : 0;
+						$set_fieldbase = "gpnotify_sets_{$project->id}[{$translation_set->locale}]";
+						?>
+						<tr <?php echo $tr_class; ?>>
+							<td></td>
+							<td></td>
+							<td><?php echo esc_html($translation_set->name); ?></td>
+							<td><input type="checkbox" name="<?php echo $set_fieldbase; ?>" <?php checked($set_waiting); ?> value="1" /></td>
+						</tr>
+						<?php
+						
+					}
+					?>
+				</tbody>
 			<?php $i++; } ?>
-			</tbody>
-
 		</table>
-
+		<table>
+			<tr>
+				<p><?php esc_html_e('Notify me', 'glotpress-notify'); ?>&nbsp;&nbsp;
+					<label>
+						<input type="checkbox" name="frequency[]" value="day" <?php echo (in_array('day', $project_options['frequency'])) ? 'checked="checked"':'' ?> />
+						<?php esc_html_e('Daily', 'glotpress-notify'); ?>
+					</label> 
+					<label>
+						<input type="checkbox" name="frequency[]" value="week" <?php echo (in_array('week', $project_options['frequency'])) ? 'checked="checked"':'' ?> />
+						<?php esc_html_e('Weekly', 'glotpress-notify'); ?>
+					</label> 
+					<label>
+						<input type="checkbox" name="frequency[]" value="month" <?php echo (in_array('month', $project_options['frequency'])) ? 'checked="checked"':'' ?> />
+						<?php esc_html_e('Monthly', 'glotpress-notify'); ?>
+					</label></p>
 		<p class="submit">
-			<input type="submit" name="submit" class="button-primary" value="<?php esc_attr_e('Save Subscriptions', 'gpnotify'); ?>" />
+			<input type="submit" name="submit" class="button-primary" value="<?php esc_attr_e('Save Subscriptions', 'glotpress-notify'); ?>" />
 			<?php wp_nonce_field('subscribe', 'gpnotify_nonce'); ?>
 		</p>
 
 	</form>
-
+	<script type="text/javascript">
+		jQuery(document).ready(function($){
+			$('input.project-notify:checkbox').click(function(){
+				var box = $(this);
+				$('tbody.'+ box.attr('id') +'-langs input:checkbox').prop('checked', box.prop("checked"));
+			});
+		});
+	</script>
 </div>
 


### PR DESCRIPTION
There's a few main changes:
- Added per-language email notification settings for user to choose from. They can now subscribe to a specific language, or a whole project. Each language subscription will receive its own email, whereas projects get their own email with all languages with waiting translations.
- Changed notifications to be sent daily, weekly or monthly, meaning a user won't be notified every day for the same string awaiting translation if it isn't translated. If daily for example, an email will be sent each day summing up new waiting strings from that day, or no email is sent at all.
- Also added inclusion of notification for new originals needing if a user subscribes to a language or project
